### PR TITLE
Make `matrix` values generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # rapids-dependency-file-generator
 
-`rapids-dependency-file-generator` is a Python CLI tool that generates conda `environment.yaml` files and `requirements.txt` files from a single YAML file, typically named `dependencies.yaml`. When installed, it makes the `rapids-dependency-file-generator` CLI command available which is responsible for parsing a `dependencies.yaml` configuration file and generating the appropriate conda `environment.yaml` and `requirements.txt` dependency files.
+`rapids-dependency-file-generator` is a Python CLI tool that generates conda `environment.yaml` files and `requirements.txt` files from a single YAML file, typically named `dependencies.yaml`.
+
+When installed, it makes the `rapids-dependency-file-generator` CLI command available which is responsible for parsing a `dependencies.yaml` configuration file and generating the appropriate conda `environment.yaml` and `requirements.txt` dependency files.
 
 ## Table of Contents
 
@@ -23,7 +25,9 @@ pip install rapids-dependency-file-generator
 
 ## Usage
 
-When `rapids-dependency-file-generator` is invoked, it will read a `dependencies.yaml` file from the current directory and generate children dependency files. The `dependencies.yaml` file has the following characteristics:
+When `rapids-dependency-file-generator` is invoked, it will read a `dependencies.yaml` file from the current directory and generate children dependency files.
+
+The `dependencies.yaml` file has the following characteristics:
 
 - it is intended to be committed to the root directory of repositories
 - it can define matrices that enable the output dependency files to vary according to any arbitrary specification (or combination of specifications), including CUDA version, machine architecture, Python version, etc.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install rapids-dependency-file-generator
 When `rapids-dependency-file-generator` is invoked, it will read a `dependencies.yaml` file from the current directory and generate children dependency files. The `dependencies.yaml` file has the following characteristics:
 
 - it is intended to be committed to the root directory of repositories
-- it can define matrices that enable the outputted dependency files to vary according to any arbitrary specification (or combination of specifications), including CUDA version, machine architecture, Python version, etc.
+- it can define matrices that enable the output dependency files to vary according to any arbitrary specification (or combination of specifications), including CUDA version, machine architecture, Python version, etc.
 - it contains bifurcated lists of dependencies based on the dependency's purpose (i.e. build, runtime, test, etc.). The bifurcated dependency lists are merged according to the description in the [_How Dependency Lists Are Merged_](#how-dependency-lists-are-merged) section below.
 
 ## `dependencies.yaml` Format

--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ ENV_NAME="cudf_test"
 rapids-dependency-file-generator \
   --file_key "test" \
   --generate "conda" \
-  --cuda_version "11.5" \
-  --arch $(arch) > env.yaml
+  --matrix "cuda=11.5;arch=$(arch)" > env.yaml
 mamba env create --file env.yaml
 mamba activate "$ENV_NAME"
 

--- a/src/rapids_dependency_file_generator/cli.py
+++ b/src/rapids_dependency_file_generator/cli.py
@@ -5,19 +5,18 @@ import yaml
 import argparse
 
 
-def generate_file_obj(config_file, file_key, file_type, cuda_version, arch):
-    if not (config_file and file_key and file_type and cuda_version and arch):
+def generate_file_obj(config_file, file_key, file_type, matrix):
+    if not (config_file and file_key and file_type and matrix):
         return {}
     with open(config_file, "r") as f:
         parsed_config = yaml.load(f, Loader=yaml.FullLoader)
-    matrix = {"cuda_version": [cuda_version], "arch": [arch]}
     parsed_config["files"][file_key]["matrix"] = matrix
     parsed_config["files"][file_key]["generate"] = file_type
     return {file_key: parsed_config["files"][file_key]}
 
 
 def validate_args(args):
-    dependent_arg_keys = ["file_key", "generate", "cuda_version", "arch"]
+    dependent_arg_keys = ["file_key", "generate", "matrix"]
     dependent_arg_values = []
     for i in range(len(dependent_arg_keys)):
         dependent_arg_values.append(getattr(args, dependent_arg_keys[i]))
@@ -26,6 +25,14 @@ def validate_args(args):
             "The following arguments must be used together:"
             + "".join([f"\n  --{x}" for x in dependent_arg_keys])
         )
+
+
+def generate_matrix(matrix_arg):
+    matrix = {}
+    for matrix_column in matrix_arg.split(";"):
+        kv_pair = matrix_column.split("=")
+        matrix[kv_pair[0]] = [kv_pair[1]]
+    return matrix
 
 
 def main():
@@ -38,28 +45,23 @@ def main():
         help="path to YAML config file",
     )
 
-    inclusive_group = parser.add_argument_group("optional, but mutually inclusive")
-    inclusive_group.add_argument(
+    codependent_args = parser.add_argument_group("optional, but codependent")
+    codependent_args.add_argument(
         "--file_key",
         help="The file key from `dependencies.yaml` to generate",
     )
-    inclusive_group.add_argument(
+    codependent_args.add_argument(
         "--generate",
         help="The file type to generate",
         choices=[str(x) for x in [GeneratorTypes.CONDA, GeneratorTypes.REQUIREMENTS]],
     )
-    inclusive_group.add_argument(
-        "--cuda_version",
-        help="The CUDA version used for generating the output",
-    )
-    inclusive_group.add_argument(
-        "--arch",
-        help="The architecture used for generating the output",
+    codependent_args.add_argument(
+        "--matrix",
+        help='string representing which matrix combination should be generated. i.e. --matrix "cuda=11.5;arch=x86_64"',
     )
 
     args = parser.parse_args()
     validate_args(args)
-    file = generate_file_obj(
-        args.config, args.file_key, args.generate, args.cuda_version, args.arch
-    )
+    matrix = generate_matrix(args.matrix)
+    file = generate_file_obj(args.config, args.file_key, args.generate, matrix)
     dfg(args.config, file)

--- a/src/rapids_dependency_file_generator/cli.py
+++ b/src/rapids_dependency_file_generator/cli.py
@@ -57,7 +57,7 @@ def main():
     )
     codependent_args.add_argument(
         "--matrix",
-        help='string representing which matrix combination should be generated. i.e. --matrix "cuda=11.5;arch=x86_64"',
+        help='string representing which matrix combination should be generated, such as `--matrix "cuda=11.5;arch=x86_64"`',
     )
 
     args = parser.parse_args()

--- a/src/rapids_dependency_file_generator/constants.py
+++ b/src/rapids_dependency_file_generator/constants.py
@@ -26,7 +26,3 @@ default_channels = [
 default_conda_dir = "conda/environments"
 default_requirements_dir = "python"
 default_dependency_file_path = "dependencies.yaml"
-
-
-def arch_cuda_key_fmt(arch, cuda_version):
-    return f"{arch}-{cuda_version}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from unittest.mock import mock_open
-from rapids_dependency_file_generator.cli import generate_file_obj
+from rapids_dependency_file_generator.cli import generate_file_obj, generate_matrix
 
 mock_yaml = """
 files:
@@ -18,34 +18,35 @@ files:
 )
 def test_generate_file_obj():
     # valid env
-    file_obj = generate_file_obj("na_file", "test", "conda", "11.5", "x86_64")
+    file_obj = generate_file_obj(
+        "na_file", "test", "conda", {"cuda": ["11.5"], "arch": ["x86_64"]}
+    )
 
     assert file_obj == {
         "test": {
             "generate": "conda",
-            "matrix": {"cuda_version": ["11.5"], "arch": ["x86_64"]},
+            "matrix": {"cuda": ["11.5"], "arch": ["x86_64"]},
             "includes": ["build", "test"],
         }
     }
 
     # invalid env: missing config_file
-    file_obj = generate_file_obj("", "file_key", "file_type", "cuda_version", "arch")
+    file_obj = generate_file_obj("", "file_key", "file_type", "matrix")
     assert file_obj == {}
 
     # invalid env: missing file_key
-    file_obj = generate_file_obj("config_file", "", "file_type", "cuda_version", "arch")
+    file_obj = generate_file_obj("config_file", "", "file_type", "matrix")
     assert file_obj == {}
 
     # invalid env: missing file_type
-    file_obj = generate_file_obj("config_file", "file_key", "", "cuda_version", "arch")
+    file_obj = generate_file_obj("config_file", "file_key", "", "matrix")
     assert file_obj == {}
 
-    # invalid env: missing cuda_version
-    file_obj = generate_file_obj("config_file", "file_key", "file_type", "", "arch")
+    # invalid env: missing matrix
+    file_obj = generate_file_obj("config_file", "file_key", "file_type", "")
     assert file_obj == {}
 
-    # invalid env: missing arch
-    file_obj = generate_file_obj(
-        "config_file", "file_key", "file_type", "cuda_version", ""
-    )
-    assert file_obj == {}
+
+def test_generate_matrix():
+    matrix = generate_matrix("cuda=11.5;arch=x86_64")
+    assert matrix == {'cuda': ["11.5"], "arch": ["x86_64"]}

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -2,6 +2,7 @@ from unittest import mock
 from rapids_dependency_file_generator.rapids_dependency_file_generator import (
     dedupe,
     make_dependency_file,
+    should_use_specific_entry,
 )
 from rapids_dependency_file_generator.constants import cli_name
 import yaml
@@ -59,3 +60,23 @@ def test_make_dependency_file(mock_relpath):
         ["dep1", "dep2"],
     )
     assert env == header + "dep1\ndep2\n"
+
+
+def test_should_use_specific_entry():
+    # no match
+    matrix_combo = {"cuda": "11.5", "arch": "x86_64"}
+    specific_entry = {"cuda": "11.6"}
+    result = should_use_specific_entry(matrix_combo, specific_entry)
+    assert result == False
+
+    # one match
+    matrix_combo = {"cuda": "11.5", "arch": "x86_64"}
+    specific_entry = {"cuda": "11.5"}
+    result = should_use_specific_entry(matrix_combo, specific_entry)
+    assert result == True
+
+    # many matches
+    matrix_combo = {"cuda": "11.5", "arch": "x86_64", "python": "3.6"}
+    specific_entry = {"cuda": "11.5", "arch": "x86_64"}
+    result = should_use_specific_entry(matrix_combo, specific_entry)
+    assert result == True


### PR DESCRIPTION
This PR adjusts the `rapids-dependency-file-generator` tool to be able to accommodate any arbitrary set of matrix values instead of just `cuda` and `arch` values.