### PR TITLE
Refactor `dependencies.yaml` reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.egg-info
 dist
 tests/**/actual
+.vscode

--- a/src/rapids_dependency_file_generator/cli.py
+++ b/src/rapids_dependency_file_generator/cli.py
@@ -7,29 +7,7 @@ from .constants import OutputTypes, default_dependency_file_path
 from .rapids_dependency_file_generator import make_dependency_files
 
 
-def validate_args(args):
-    dependent_arg_keys = ["file_key", "output", "matrix"]
-    dependent_arg_values = []
-    for i in range(len(dependent_arg_keys)):
-        dependent_arg_values.append(getattr(args, dependent_arg_keys[i]))
-    if any(dependent_arg_values) and not all(dependent_arg_values):
-        raise ValueError(
-            "The following arguments must be used together:"
-            + "".join([f"\n  --{x}" for x in dependent_arg_keys])
-        )
-
-
-def generate_matrix(matrix_arg):
-    if not matrix_arg:
-        return {}
-    matrix = {}
-    for matrix_column in matrix_arg.split(";"):
-        kv_pair = matrix_column.split("=")
-        matrix[kv_pair[0]] = [kv_pair[1]]
-    return matrix
-
-
-def main(argv=None):
+def validate_args(argv):
     parser = argparse.ArgumentParser(
         description=f"Generates dependency files for RAPIDS libraries (version: {version})"
     )
@@ -58,7 +36,31 @@ def main(argv=None):
     )
 
     args = parser.parse_args(argv)
-    validate_args(args)
+    dependent_arg_keys = ["file_key", "output", "matrix"]
+    dependent_arg_values = []
+    for i in range(len(dependent_arg_keys)):
+        dependent_arg_values.append(getattr(args, dependent_arg_keys[i]))
+    if any(dependent_arg_values) and not all(dependent_arg_values):
+        raise ValueError(
+            "The following arguments must be used together:"
+            + "".join([f"\n  --{x}" for x in dependent_arg_keys])
+        )
+
+    return args
+
+
+def generate_matrix(matrix_arg):
+    if not matrix_arg:
+        return {}
+    matrix = {}
+    for matrix_column in matrix_arg.split(";"):
+        kv_pair = matrix_column.split("=")
+        matrix[kv_pair[0]] = [kv_pair[1]]
+    return matrix
+
+
+def main(argv=None):
+    args = validate_args(argv)
 
     with open(args.config) as f:
         parsed_config = yaml.load(f, Loader=yaml.FullLoader)

--- a/src/rapids_dependency_file_generator/cli.py
+++ b/src/rapids_dependency_file_generator/cli.py
@@ -38,8 +38,8 @@ def validate_args(argv):
     args = parser.parse_args(argv)
     dependent_arg_keys = ["file_key", "output", "matrix"]
     dependent_arg_values = []
-    for i in range(len(dependent_arg_keys)):
-        dependent_arg_values.append(getattr(args, dependent_arg_keys[i]))
+    for key in dependent_arg_keys:
+        dependent_arg_values.append(getattr(args, key))
     if any(dependent_arg_values) and not all(dependent_arg_values):
         raise ValueError(
             "The following arguments must be used together:"

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -127,14 +127,11 @@ def should_use_specific_entry(matrix_combo, specific_entry_matrix):
     return True
 
 
-def make_dependency_files(config_file_path, files=None):
-    with open(config_file_path) as f:
-        parsed_config = yaml.load(f, Loader=yaml.FullLoader)
+def make_dependency_files(parsed_config, config_file_path, to_stdout):
 
     channels = parsed_config.get("channels", default_channels) or default_channels
     dependency_entries = parsed_config["dependencies"]
-    to_stdout = True if files else False
-    files = files or parsed_config["files"]
+    files = parsed_config["files"]
     for file_name, file_config in files.items():
         includes = file_config["includes"]
         file_types_to_generate = get_file_output(file_config["output"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,53 +1,9 @@
-from unittest import mock
-from unittest.mock import mock_open
-
-from rapids_dependency_file_generator.cli import generate_file_obj, generate_matrix
-
-mock_yaml = """
-files:
-  test:
-    output: none
-    includes:
-      - build
-      - test
-"""
-
-
-@mock.patch(
-    "builtins.open",
-    mock_open(read_data=mock_yaml),
-)
-def test_generate_file_obj():
-    # valid env
-    file_obj = generate_file_obj(
-        "na_file", "test", "conda", {"cuda": ["11.5"], "arch": ["x86_64"]}
-    )
-
-    assert file_obj == {
-        "test": {
-            "output": "conda",
-            "matrix": {"cuda": ["11.5"], "arch": ["x86_64"]},
-            "includes": ["build", "test"],
-        }
-    }
-
-    # invalid env: missing config_file
-    file_obj = generate_file_obj("", "file_key", "file_type", "matrix")
-    assert file_obj == {}
-
-    # invalid env: missing file_key
-    file_obj = generate_file_obj("config_file", "", "file_type", "matrix")
-    assert file_obj == {}
-
-    # invalid env: missing file_type
-    file_obj = generate_file_obj("config_file", "file_key", "", "matrix")
-    assert file_obj == {}
-
-    # invalid env: missing matrix
-    file_obj = generate_file_obj("config_file", "file_key", "file_type", "")
-    assert file_obj == {}
+from rapids_dependency_file_generator.cli import generate_matrix
 
 
 def test_generate_matrix():
     matrix = generate_matrix("cuda=11.5;arch=x86_64")
     assert matrix == {"cuda": ["11.5"], "arch": ["x86_64"]}
+
+    matrix = generate_matrix(None)
+    assert matrix == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
-from rapids_dependency_file_generator.cli import generate_matrix
+import pytest
+
+from rapids_dependency_file_generator.cli import generate_matrix, validate_args
 
 
 def test_generate_matrix():
@@ -7,3 +9,29 @@ def test_generate_matrix():
 
     matrix = generate_matrix(None)
     assert matrix == {}
+
+
+def test_validate_args():
+    # Missing output
+    with pytest.raises(Exception):
+        validate_args(["--matrix", "cuda=11.5;arch=x86_64", "--file_key", "all"])
+
+    # Missing matrix
+    with pytest.raises(Exception):
+        validate_args(["--output", "conda", "--file_key", "all"])
+
+    # Missing file_key
+    with pytest.raises(Exception):
+        validate_args(["--output", "conda", "--matrix", "cuda=11.5;arch=x86_64"])
+
+    # Valid
+    validate_args(
+        [
+            "--output",
+            "conda",
+            "--matrix",
+            "cuda=11.5;arch=x86_64",
+            "--file_key",
+            "all",
+        ]
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,9 +5,7 @@ import shutil
 
 import pytest
 
-from rapids_dependency_file_generator.rapids_dependency_file_generator import (
-    make_dependency_files,
-)
+from rapids_dependency_file_generator.cli import main
 
 CURRENT_DIR = pathlib.Path(__file__).parent
 
@@ -36,7 +34,7 @@ def test_examples(test_name):
     actual_dir = test_dir.joinpath("output", "actual")
     dep_file_path = test_dir.joinpath("dependencies.yaml")
 
-    make_dependency_files(dep_file_path)
+    main(["--config", str(dep_file_path)])
 
     expected_file_set = make_file_set(expected_dir)
     actual_file_set = make_file_set(actual_dir)


### PR DESCRIPTION
This PR refactors some things to ensure that the `dependencies.yaml` file is only ever read from the file system a single time.