### PR TITLE
Swap conda-forge and nvidia channel priority.

### DIFF
--- a/src/rapids_dependency_file_generator/constants.py
+++ b/src/rapids_dependency_file_generator/constants.py
@@ -14,10 +14,10 @@ cli_name = "rapids-dependency-file-generator"
 
 default_channels = [
     "rapidsai",
-    "nvidia",
     "rapidsai-nightly",
     "dask/label/dev",
     "conda-forge",
+    "nvidia",
 ]
 
 default_conda_dir = "conda/environments"


### PR DESCRIPTION
Needed for cuda-python updates / 22.10.01 hotfix. We must prioritize `conda-forge` over `nvidia` to get the right `cuda-python` builds.