### PR TITLE
fix: Add PyPI Uploads to semantic-release process

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -6,10 +6,13 @@ runs:
       with:
         python-version: "3.10"
     - name: Install Python Packages
+      shell: bash
       run: pip install build pytest
     - name: Build Python Package
+      shell: bash
       run: python -m build .
     - name: Test Python Packages
+      shell: bash
       run: |
         #!/bin/bash
         for PKG in dist/*; do

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,28 +1,21 @@
-on:
-  workflow_call:
-
-jobs:
-  pipeline:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install Python Packages
-        run: pip install build pytest
-      - name: Build Python Package
-        run: python -m build .
-      - name: Test Python Packages
-        run: |
-          #!/bin/bash
-          for PKG in dist/*; do
-            echo "$PKG"
-            pip uninstall -y rapids-dependency-file-generator
-            pip install "$PKG"
-            pytest
-            rapids-dependency-file-generator -h # test CLI output
-          done
+name: "Build and Test"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Python Packages
+      run: pip install build pytest
+    - name: Build Python Package
+      run: python -m build .
+    - name: Test Python Packages
+      run: |
+        #!/bin/bash
+        for PKG in dist/*; do
+          echo "$PKG"
+          pip uninstall -y rapids-dependency-file-generator
+          pip install "$PKG"
+          pytest
+          rapids-dependency-file-generator -h # test CLI output
+        done

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -9,4 +9,10 @@ concurrency:
 
 jobs:
   build-test:
-    uses: ./.github/workflows/build-test.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/workflows/build-test.yaml

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ./.github/workflows/build-test.yaml
+      - uses: ./.github/actions/build-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,16 +12,14 @@ on:
       - ".github/workflows/release.yaml"
 
 jobs:
-  build-test:
-    uses: ./.github/workflows/build-test.yaml
   release:
-    needs: build-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: ./.github/workflows/build-test.yaml
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ./.github/workflows/build-test.yaml
+      - uses: ./.github/actions/build-test
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,9 +24,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
-      - name: Release
+      - name: GH Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install @semantic-release/exec@6 -D
           npx semantic-release@19
+      - name: PyPI Release
+        run: |
+          twine upload \
+            --username __token__ \
+            --password ${{ secrets.RAPIDSAI_PYPI_TOKEN }} \
+            --disable-progress-bar \
+            dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,16 +24,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
-      - name: GH Release
+      - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
         run: |
           npm install @semantic-release/exec@6 -D
           npx semantic-release@19
-      - name: PyPI Release
-        run: |
-          twine upload \
-            --username __token__ \
-            --password ${{ secrets.RAPIDSAI_PYPI_TOKEN }} \
-            --disable-progress-bar \
-            dist/*

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  semantic-pr-title:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -6,3 +6,4 @@ plugins:
   - "@semantic-release/github"
   - - "@semantic-release/exec"
     - prepareCmd: ./ci/update-version.sh ${nextRelease.version}
+      publishCmd: ./ci/pypi-publish.sh

--- a/ci/pypi-publish.sh
+++ b/ci/pypi-publish.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Simple script to upload packages to PyPI
+set -ue
+
+twine upload \
+  --username __token__ \
+  --password "${PYPI_TOKEN}" \
+  --disable-progress-bar \
+  dist/*

--- a/ci/update-version.sh
+++ b/ci/update-version.sh
@@ -5,3 +5,5 @@ set -ue
 NEXT_VERSION=$1
 
 sed -i "/__version__/ s/\".*\"/\"${NEXT_VERSION}\"/" src/rapids_dependency_file_generator/_version.py
+
+cat src/rapids_dependency_file_generator/_version.py


### PR DESCRIPTION
This PR re-adds PyPI uploads to our new semantic-release process.

To make this work, the `build-test.yaml` file needed to be switched from a reusable job to a composite action so that the built files exist on the machine that will do the release.