### PR TITLE
fix: Remove `paths` filter from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "src/**"
-      - "setup.cfg"
-      - "setup.py"
-      - "pyproject.toml"
-      - ".github/workflows/release.yaml"
 
 jobs:
   release:


### PR DESCRIPTION
This PR removes the `paths` filter from the release workflow.

This will shift the responsibility of determining when a release should occur from GitHub Actions to `semantic-release` via semantic commit messages.