### PR TITLE
fix: Update PyPI release information for `semantic-release`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: prs
+name: pr
 
 on:
   pull_request:

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -1,4 +1,4 @@
-name: semantic-pr-title
+name: pr-title
 
 on:
   pull_request_target:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  semantic-pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -3,7 +3,8 @@ branches:
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/github"
+  - - "@semantic-release/github"
+    - addReleases: top
   - - "@semantic-release/exec"
     - verifyReleaseCmd: ./ci/update-version.sh ${nextRelease.version} && ./ci/build-test.sh
       publishCmd: ./ci/pypi-publish.sh

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 # Builds and tests Python package
+# Per https://github.com/semantic-release/exec:
+#  - stderr is used for logging
+#  - stdout is used for printing why verification failed
 set -ue
 
-pip install build pytest
+{
+  pip install build pytest
 
-python -m build .
+  python -m build .
 
-for PKG in dist/*; do
-  echo "$PKG"
-  pip uninstall -y rapids-dependency-file-generator
-  pip install "$PKG"
-  pytest
-  rapids-dependency-file-generator -h # test CLI output
-done
+  for PKG in dist/*; do
+    echo "$PKG"
+    pip uninstall -y rapids-dependency-file-generator
+    pip install "$PKG"
+    pytest
+    rapids-dependency-file-generator -h # test CLI output
+  done
+} 1>&2

--- a/ci/pypi-publish.sh
+++ b/ci/pypi-publish.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Uploads packages to PyPI
+# Per https://github.com/semantic-release/exec:
+#  - stderr is used for logging
+#  - stdout is used for returning release information
 set -ue
 
-pip install twine
+{
+  pip install twine
 
-twine upload \
-  --username __token__ \
-  --password "${PYPI_TOKEN}" \
-  --disable-progress-bar \
-  dist/*
+  twine upload \
+    --username __token__ \
+    --password "${PYPI_TOKEN}" \
+    --disable-progress-bar \
+    dist/*
+} 1>&2
+
+jq -ncr '{name: "PyPI release", url: "https://pypi.org/project/rapids-dependency-file-generator/"}'

--- a/ci/update-version.sh
+++ b/ci/update-version.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Updates the version string in `_version.py`
+# Per https://github.com/semantic-release/exec:
+#  - stderr is used for logging
+#  - stdout is used for printing why verification failed
 set -ue
 
 NEXT_VERSION=$1
 
-sed -i "/__version__/ s/\".*\"/\"${NEXT_VERSION}\"/" src/rapids_dependency_file_generator/_version.py
+{
+  sed -i "/__version__/ s/\".*\"/\"${NEXT_VERSION}\"/" src/rapids_dependency_file_generator/_version.py
 
-cat src/rapids_dependency_file_generator/_version.py
+  cat src/rapids_dependency_file_generator/_version.py
+} 1>&2


### PR DESCRIPTION
As per the docs for [semantic-release/exec](https://github.com/semantic-release/exec), the `stdout` output for `publishCmd` can be used to add PyPI release information to `semantic-release`. This should make the PyPI release URL appear in the GitHub release body and the PR comments left by `semantic-release`.