### PR TITLE
Validate dependencies.yaml using jsonschema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "PyYAML",
+    "jsonschema",
 ]
 
 [project.scripts]

--- a/src/rapids_dependency_file_generator/cli.py
+++ b/src/rapids_dependency_file_generator/cli.py
@@ -5,6 +5,7 @@ import yaml
 from ._version import __version__ as version
 from .constants import OutputTypes, default_dependency_file_path
 from .rapids_dependency_file_generator import make_dependency_files
+from .rapids_dependency_file_validator import validate_dependencies
 
 
 def validate_args(argv):
@@ -15,6 +16,11 @@ def validate_args(argv):
         "--config",
         default=default_dependency_file_path,
         help="Path to YAML config file",
+    )
+    parser.add_argument(
+        "--validate",
+        default=True,
+        help="Validate the config file in full before generating anything.",
     )
 
     codependent_args = parser.add_argument_group("optional, but codependent")
@@ -62,6 +68,9 @@ def main(argv=None):
 
     with open(args.config) as f:
         parsed_config = yaml.load(f, Loader=yaml.FullLoader)
+
+    if args.validate:
+        validate_dependencies(parsed_config)
 
     matrix = generate_matrix(args.matrix)
     to_stdout = all([args.file_key, args.output, args.matrix is not None])

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
@@ -1,7 +1,8 @@
 """Logic for validating dependency files."""
 
+import textwrap
+
 import jsonschema
-import yaml
 
 SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -132,8 +133,22 @@ SCHEMA = {
 }
 
 
-fn = "/home/nfs/vyasr/local/dependency-file-generator/tests/examples/no-specific-match/dependencies.yaml"
-with open(fn) as f:
-    dependency_data = yaml.load(f, Loader=yaml.FullLoader)
+def validate_dependencies(dependencies):
+    """Valid a dictionary against the dependencies.yaml spec.
 
-jsonschema.validate(dependency_data, schema=SCHEMA)
+    Parameters
+    ----------
+    dependencies : dict
+        The parsed dependencies.yaml file.
+
+    Raises
+    ------
+    jsonschema.exceptions.ValidationError
+        If the dependencies do not conform to the schema
+    """
+    validator = jsonschema.Draft7Validator(SCHEMA)
+    if not validator.is_valid(dependencies):
+        for i, error in enumerate(validator.iter_errors(dependencies), start=1):
+            print(f"Error #{i}:")
+            print(textwrap.indent(str(error), "\t"))
+        raise RuntimeError("The provided dependencies data is invalid.")

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
@@ -1,0 +1,139 @@
+"""Logic for validating dependency files."""
+
+import jsonschema
+import yaml
+
+SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/rapidsai/dependency-file-generator/schema.json",
+    "type": "object",
+    "title": "Dependencies",
+    "description": "A list of all dependencies for a project.",
+    "properties": {
+        "files": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "properties": {
+                        "output": {
+                            "type": ["string", "array"],
+                            "if": {"type": "array"},
+                            "then": {"items": {"type": "string"}},
+                        },
+                        "conda_dir": {"type": "string"},
+                        "requirements_dir": {"type": "string"},
+                        "matrix": {"type": "object"},
+                        "includes": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["output", "includes"],
+                }
+            },
+        },
+        "channels": {
+            "type": ["array", "string"],
+            "if": {"type": "array"},
+            "then": {"items": {"type": "string"}},
+        },
+        "dependencies": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "properties": {
+                        "common": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "output_types": {
+                                        "type": ["array", "string"],
+                                        "if": {"type": "array"},
+                                        "then": {"items": {"type": "string"}},
+                                    },
+                                    "packages": {
+                                        "type": ["array", "string"],
+                                        "if": {"type": "array"},
+                                        "then": {
+                                            "items": {"type": ["string", "object"]},
+                                            "if": {"type": "object"},
+                                            "then": {
+                                                "patternProperties": {
+                                                    ".*": {
+                                                        "type": ["array", "string"],
+                                                        "if": {"type": "array"},
+                                                        "then": {
+                                                            "items": {"type": "string"}
+                                                        },
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        "specific": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "output_types": {
+                                        "type": ["array", "string"],
+                                        "if": {"type": "array"},
+                                        "then": {"items": {"type": "string"}},
+                                    },
+                                    "matrices": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "matrix": {"type": ["null", "object"]},
+                                                "packages": {
+                                                    "type": ["null", "array", "string"],
+                                                    "if": {"type": "array"},
+                                                    "then": {
+                                                        "items": {
+                                                            "type": ["string", "object"]
+                                                        },
+                                                        "if": {"type": "object"},
+                                                        "then": {
+                                                            "patternProperties": {
+                                                                ".*": {
+                                                                    "type": [
+                                                                        "array",
+                                                                        "string",
+                                                                    ],
+                                                                    "if": {
+                                                                        "type": "array"
+                                                                    },
+                                                                    "then": {
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                }
+                                                            }
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+        },
+    },
+    "required": ["files", "dependencies"],
+}
+
+
+fn = "/home/nfs/vyasr/local/dependency-file-generator/tests/examples/no-specific-match/dependencies.yaml"
+with open(fn) as f:
+    dependency_data = yaml.load(f, Loader=yaml.FullLoader)
+
+jsonschema.validate(dependency_data, schema=SCHEMA)


### PR DESCRIPTION
This PR enables validating the contents of a dependencies.yaml file directly without doing any processing. The schema is encoded using [JSON Schema](https://json-schema.org/) and validated using [the Python implementation](https://python-jsonschema.readthedocs.io/). The new Python code is fairly minimal, and it would be even shorter except that I leveraged the object-oriented API to show all errors in a file instead of simply showing the first error using `jsonschema.validate`. The vast majority of the new lines are from the schema definition. If we end up merging these changes, then I would recommend moving the schema into a separate JSON file rather than encoding it directly in a Python module, but the current implementation is a sufficient POC.

Whether or not we merge this PR, we should consider updating our schema to change all keys that accept either single strings or arrays of strings to always require the arrays. That would simplify both the schema and our actual parsing code.