### PR TITLE
fix: Fix conditional statement

### DIFF
--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -351,7 +351,8 @@ def make_dependency_files(parsed_config, config_file_path, to_stdout):
     channels = parsed_config.get("channels", default_channels) or default_channels
     files = parsed_config["files"]
     if to_stdout and any(
-        OutputTypes.PYPROJECT in get_requested_output_types(f["output"]) for f in files
+        OutputTypes.PYPROJECT in get_requested_output_types(files[f]["output"])
+        for f in files
     ):
         raise ValueError("to_stdout is not supported for pyproject.toml files.")
     for file_key, file_config in files.items():


### PR DESCRIPTION
There is currently a conditional statement that is incorrectly attempting to index a string instead of retrieving a value from a dictionary.

Instead of accessing `f["output"]`, it needs to be adjusted to `files[f]["output"]`

The code excerpt below shows a minimal reproducer of the problem and the solution.

```python
files = {'checks': {'matrix': {'cuda': ['11.8'], 'arch': ['x86_64'], 'py': ['3.10']}, 'output': 'conda', 'includes': ['checks', 'py_version']}}

# this throws error: "TypeError: string indices must be integers"
for f in files:
  f["output"]

# this fixes it
for f in files:
   files[f]["output"]
```