### PR TITLE
feat: Generate meta.yaml dependencies

### DIFF
--- a/src/rapids_dependency_file_generator/constants.py
+++ b/src/rapids_dependency_file_generator/constants.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class OutputTypes(Enum):
     CONDA = "conda"
+    CONDA_META = "conda_meta"
     REQUIREMENTS = "requirements"
     PYPROJECT = "pyproject"
     NONE = "none"
@@ -22,6 +23,7 @@ default_channels = [
 ]
 
 default_conda_dir = "conda/environments"
+default_conda_meta_dir = "conda/recipes/"
 default_requirements_dir = "python"
 default_pyproject_dir = "python"
 default_dependency_file_path = "dependencies.yaml"

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -55,6 +55,8 @@ def dedupe(dependencies):
     """
     deduped = sorted({dep for dep in dependencies if not isinstance(dep, dict)})
     dict_deps = defaultdict(list)
+    # The purpose of the outer loop is to support nested dependency lists such as the
+    # `pip:` list. If multiple are present, they must be internally deduped as well.
     for dep in filter(lambda dep: isinstance(dep, dict), dependencies):
         for key, values in dep.items():
             dict_deps[key].extend(values)
@@ -83,6 +85,10 @@ def grid(gridspec):
     Iterable[dict]
         Each yielded value is a dictionary containing one of the unique
         combinations of parameter values from `gridspec`.
+
+    Notes
+    -----
+    An empty `gridspec` dict will result in an empty dict as the single yielded value.
     """
     for values in itertools.product(*gridspec.values()):
         yield dict(zip(gridspec.keys(), values))

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -267,7 +267,6 @@ def get_filename(file_type, file_key, matrix_combo, extras=None):
                 ],
             )
         )
-        print(file_type_prefix)
     elif file_type == str(OutputTypes.REQUIREMENTS):
         file_ext = ".txt"
         file_type_prefix = "requirements"
@@ -412,8 +411,6 @@ def make_dependency_files(parsed_config, config_file_path, to_stdout):
                         dependencies.extend(common_entry["packages"])
 
                     for specific_entry in dependency_entry.get("specific", []):
-                        # if include == "build_cpp":
-                        #     breakpoint()
                         if file_type not in specific_entry["output_types"]:
                             continue
 
@@ -478,7 +475,6 @@ def make_dependency_files(parsed_config, config_file_path, to_stdout):
                 if to_stdout:
                     print(contents)
                 else:
-                    # breakpoint()
                     os.makedirs(output_dir, exist_ok=True)
                     file_path = os.path.join(output_dir, full_file_name)
                     with open(file_path, "w") as f:

--- a/src/rapids_dependency_file_generator/schema.json
+++ b/src/rapids_dependency_file_generator/schema.json
@@ -175,7 +175,7 @@
                 "additionalProperties": false
             },
             "if": {
-                "properties": { "table": { "const": "project.optional-dependencies" } }
+                "properties": { "table": { "const": "project.optional-dependencies" }, "required": ["table"] }
             },
             "then": {
                 "required": ["key"]

--- a/src/rapids_dependency_file_generator/schema.json
+++ b/src/rapids_dependency_file_generator/schema.json
@@ -17,6 +17,7 @@
                         "matrix": {"$ref": "#/$defs/matrix"},
                         "requirements_dir": {"type": "string"},
                         "conda_dir": {"type": "string"},
+                        "conda_meta_dir": {"type": "string"},
                         "pyproject_dir": {"type": "string"}
                     },
                     "additionalProperties": false,
@@ -118,7 +119,7 @@
             "items": {"$ref": "#/$defs/matrix-matcher"}
         },
         "output-types": {
-            "enum": ["conda", "requirements", "pyproject"]
+            "enum": ["conda", "conda_meta", "requirements", "pyproject"]
         },
         "output-types-array": {
             "type": "array",
@@ -162,11 +163,16 @@
         "extras": {
             "type": "object",
             "properties": {
+                "section": {
+                    "type": "string",
+                    "enum": ["build", "host", "run"]
+                },
                 "table": {
                     "type": "string",
                     "enum": ["build-system", "project", "project.optional-dependencies"]
                 },
-                "key": {"type": "string"}
+                "key": {"type": "string"},
+                "additionalProperties": false
             },
             "if": {
                 "properties": { "table": { "const": "project.optional-dependencies" } }

--- a/src/rapids_dependency_file_generator/schema.json
+++ b/src/rapids_dependency_file_generator/schema.json
@@ -174,17 +174,6 @@
                 "key": {"type": "string"},
                 "additionalProperties": false
             },
-            "if": {
-                "properties": { "table": { "const": "project.optional-dependencies" }, "required": ["table"] }
-            },
-            "then": {
-                "required": ["key"]
-            },
-            "else": {
-                "not": {
-                    "required": ["key"]
-                }
-            },
             "additionalProperties": false
         }
     }


### PR DESCRIPTION
This PR is an alternative to #28 that is based on generating separate dependency files instead of modifying `meta.yaml` in place. It is a much simpler changeset as a result. I considered putting the data into the `conda_build_config.yaml` file instead of using separate YAML files for each dependency set, but I rejected that option because dfg is based around writing separate `files` sections for every include list and the only way to map that to a single `conda_build_config.yaml` file is to do a lot of in-place overwriting, which we have generally decided to avoid unless absolutely necessary, i.e. for pyproject.toml (otherwise we could just do that for `meta.yaml` too). Willing to be convinced otherwise though.

In order to support split recipes, this approach requires writing separate files for every section in every output, which may be too verbose for our liking. Curious to hear opinions there.