### PR TITLE
feat: Trigger CI img rebuilds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,3 +26,14 @@ jobs:
         run: |
           npm install
           npx semantic-release
+  trigger-pipeline:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Trigger Pipeline
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+        run: |
+          gh workflow run push.yml \
+          --repo github.com/rapidsai/ci-imgs \
+          --ref main


### PR DESCRIPTION
Configures the release workflow to trigger `build-and-publish-images` workflow of `ci-imgs` due to being an upstream dependency.