### PR TITLE
fix: Remove dependency on pkg_resources

### DIFF
--- a/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
@@ -1,14 +1,16 @@
 """Logic for validating dependency files."""
 
+import importlib
 import json
 import sys
 import textwrap
 
 import jsonschema
-import pkg_resources
 from jsonschema.exceptions import best_match
 
-SCHEMA = json.loads(pkg_resources.resource_string(__name__, "schema.json"))
+SCHEMA = json.loads(
+    importlib.resources.files(__name__).joinpath("schema.json").read_bytes()
+)
 
 
 def validate_dependencies(dependencies):

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
@@ -1,6 +1,6 @@
 """Logic for validating dependency files."""
 
-import importlib
+import importlib.resources
 import json
 import sys
 import textwrap

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_validator.py
@@ -9,7 +9,7 @@ import jsonschema
 from jsonschema.exceptions import best_match
 
 SCHEMA = json.loads(
-    importlib.resources.files(__name__).joinpath("schema.json").read_bytes()
+    importlib.resources.files(__package__).joinpath("schema.json").read_bytes()
 )
 
 


### PR DESCRIPTION
Closes #53 by replacing use of `pkg_resources` with `importlib.resources`. This should fix Python 3.12 support.