### PR TITLE
fix: Avoid crash when file in repo contains non-unicode characters

### DIFF
--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -35,12 +35,12 @@ def delete_existing_files(root="."):
         for fn in filter(
             lambda fn: fn.endswith(".txt") or fn.endswith(".yaml"), filenames
         ):
-            try:
-                with open(file_path := os.path.join(dirpath, fn)) as f:
+            with open(file_path := os.path.join(dirpath, fn)) as f:
+                try:
                     if HEADER in f.read():
                         os.remove(file_path)
-            except UnicodeDecodeError:
-                pass
+                except UnicodeDecodeError:
+                    pass
 
 
 def dedupe(dependencies):

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -35,9 +35,12 @@ def delete_existing_files(root="."):
         for fn in filter(
             lambda fn: fn.endswith(".txt") or fn.endswith(".yaml"), filenames
         ):
-            with open(file_path := os.path.join(dirpath, fn)) as f:
-                if HEADER in f.read():
-                    os.remove(file_path)
+            try:
+                with open(file_path := os.path.join(dirpath, fn)) as f:
+                    if HEADER in f.read():
+                        os.remove(file_path)
+            except UnicodeDecodeError:
+                pass
 
 
 def dedupe(dependencies):


### PR DESCRIPTION
This fix prevents a crash when using `--clean` on a repo where a file contains non-unicode characters. Fix seems benign since any file with non-unicode characters likely wasnt created by this tool.

Closes #58 