### PR TITLE
ci: Ensure `ci-imgs` repo is only triggered when new releases occur

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      RELEASE_PUBLISHED: ${{ steps.semantic-release.outputs.RELEASE_PUBLISHED }}
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
@@ -24,6 +26,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Release
+        id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -31,6 +34,7 @@ jobs:
           npm install
           npx semantic-release
   trigger-pipeline:
+    if: needs.release.outputs.RELEASE_PUBLISHED == 'true'
     runs-on: ubuntu-latest
     needs: release
     steps:

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -8,6 +8,7 @@ plugins:
   - - "@semantic-release/exec"
     - verifyReleaseCmd: ./ci/update-versions.sh ${nextRelease.version} && ./ci/build-test.sh
       publishCmd: ./ci/pypi-publish.sh
+      successCmd: ./ci/semantic-release-success.sh
   - - "@semantic-release/git"
     - assets:
         - src/rapids_dependency_file_generator/_version.py

--- a/ci/semantic-release-success.sh
+++ b/ci/semantic-release-success.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "RELEASE_PUBLISHED=true" | tee --append "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
The `release.yaml` workflow currently triggers the `ci-imgs` repository to rebuild anytime a merge to `main` happens.

This PR makes the logic smarter by only triggering the `ci-imgs` repository to rebuild when an actual release occurs.

This will prevent `ci-imgs` rebuilds from occurring unnecessarily.