### PR TITLE
refactor: make configuration-passing from make_dependency_files() to make_dependency_file() stricter

### DIFF
--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -442,7 +442,7 @@ def make_dependency_files(parsed_config, config_file_path, to_stdout):
                 contents = make_dependency_file(
                     file_type=file_type,
                     name=full_file_name,
-                    confige_file=config_file_path,
+                    config_file=config_file_path,
                     output_dir=output_dir,
                     conda_channels=channels,
                     dependencies=deduped_deps,

--- a/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py
@@ -93,7 +93,7 @@ def grid(gridspec):
 
 
 def make_dependency_file(
-    file_type, name, config_file, output_dir, conda_channels, dependencies, extras=None
+    *, file_type, name, config_file, output_dir, conda_channels, dependencies, extras
 ):
     """Generate the contents of the dependency file.
 
@@ -440,13 +440,13 @@ def make_dependency_files(parsed_config, config_file_path, to_stdout):
                     else get_output_dir(file_type, config_file_path, file_config)
                 )
                 contents = make_dependency_file(
-                    file_type,
-                    full_file_name,
-                    config_file_path,
-                    output_dir,
-                    channels,
-                    deduped_deps,
-                    extras,
+                    file_type=file_type,
+                    name=full_file_name,
+                    confige_file=config_file_path,
+                    output_dir=output_dir,
+                    conda_channels=channels,
+                    dependencies=deduped_deps,
+                    extras=extras,
                 )
 
                 if to_stdout:

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -40,12 +40,13 @@ def test_make_dependency_file(mock_relpath):
 # To make changes, edit {relpath} and run `{cli_name}`.
 """
     env = make_dependency_file(
-        "conda",
-        "tmp_env.yaml",
-        "config_file",
-        "output_path",
-        ["rapidsai", "nvidia"],
-        ["dep1", "dep2"],
+        file_type="conda",
+        name="tmp_env.yaml",
+        config_file="config_file",
+        output_dir="output_path",
+        conda_channels=["rapidsai", "nvidia"],
+        dependencies=["dep1", "dep2"],
+        extras=None
     )
     assert env == header + yaml.dump(
         {
@@ -56,12 +57,13 @@ def test_make_dependency_file(mock_relpath):
     )
 
     env = make_dependency_file(
-        "requirements",
-        "tmp_env.txt",
-        "config_file",
-        "output_path",
-        ["rapidsai", "nvidia"],
-        ["dep1", "dep2"],
+        file_type="requirements",
+        name="tmp_env.txt",
+        config_file="config_file",
+        output_dir="output_path",
+        conda_channels=["rapidsai", "nvidia"],
+        dependencies=["dep1", "dep2"],
+        extras=None
     )
     assert env == header + "dep1\ndep2\n"
 

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -46,7 +46,7 @@ def test_make_dependency_file(mock_relpath):
         output_dir="output_path",
         conda_channels=["rapidsai", "nvidia"],
         dependencies=["dep1", "dep2"],
-        extras=None
+        extras=None,
     )
     assert env == header + yaml.dump(
         {
@@ -63,7 +63,7 @@ def test_make_dependency_file(mock_relpath):
         output_dir="output_path",
         conda_channels=["rapidsai", "nvidia"],
         dependencies=["dep1", "dep2"],
-        extras=None
+        extras=None,
     )
     assert env == header + "dep1\ndep2\n"
 


### PR DESCRIPTION
Similar to #64, this proposes small changes to make bugs related to passing configuration between the project's functions less likely.

* requires that `make_dependency_file()` (which takes 7 arguments) only be called with keyword arguments
* removes default on `extras` in that function

### How is this safe?

`make_dependency_file()` is only called in one place, and that place supplies a value for `extras`.

https://github.com/rapidsai/dependency-file-generator/blob/36a40613235089b4de271367ccef3674678c1555/src/rapids_dependency_file_generator/rapids_dependency_file_generator.py#L442-L450