### PR TITLE
ci: Update `GITHUB_TOKEN` for `semantic-release`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       RELEASE_PUBLISHED: ${{ steps.semantic-release.outputs.RELEASE_PUBLISHED }}
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +24,7 @@ jobs:
       - name: Release
         id: semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
         run: |
           npm install


### PR DESCRIPTION
This change switches the `GITHUB_TOKEN` used by `semantic-release` to the `WORKFLOW_TOKEN`, which is a PAT for the `GPUtester` user.

This should hopefully get us passed the release issue below:

- https://github.com/rapidsai/dependency-file-generator/actions/runs/8008126855/job/21873843459#step:5:666

This problem was introduced in #62, when I tried to replace my own PAT with the default `GITHUB_TOKEN`.