### PR TITLE
fix: Upload conda package to both `rapidsai` & `rapidsai-nightly` orgs

### DIFF
--- a/.github/actions/semantic-release/action.yaml
+++ b/.github/actions/semantic-release/action.yaml
@@ -3,7 +3,8 @@ inputs:
   GITHUB_TOKEN:
     required: true
   PYPI_TOKEN: {}
-  ANACONDA_TOKEN: {}
+  ANACONDA_STABLE_TOKEN: {}
+  ANACONDA_NIGHTLY_TOKEN: {}
   DRY_RUN:
     default: "false"
 outputs:
@@ -23,6 +24,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         PYPI_TOKEN: ${{ inputs.PYPI_TOKEN }}
-        ANACONDA_TOKEN: ${{ inputs.ANACONDA_TOKEN }}
+        ANACONDA_STABLE_TOKEN: ${{ inputs.ANACONDA_STABLE_TOKEN }}
+        ANACONDA_NIGHTLY_TOKEN: ${{ inputs.ANACONDA_NIGHTLY_TOKEN }}
         DRY_RUN: ${{ inputs.DRY_RUN }}
       run: ${GITHUB_ACTION_PATH}/semantic-release.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,8 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
-          ANACONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
+          ANACONDA_STABLE_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
+          ANACONDA_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       - name: Trigger CI Images
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -12,7 +12,9 @@ plugins:
   - - "@semantic-release/exec"
     - publishCmd: ./ci/publish/wheel.sh
   - - "@semantic-release/exec"
-    - publishCmd: ./ci/publish/conda.sh
+    - publishCmd: ./ci/publish/conda.sh rapidsai
+  - - "@semantic-release/exec"
+    - publishCmd: ./ci/publish/conda.sh rapidsai-nightly
   - - "@semantic-release/git"
     - assets:
         - src/rapids_dependency_file_generator/_version.py

--- a/ci/publish/conda.sh
+++ b/ci/publish/conda.sh
@@ -11,11 +11,27 @@ set -euo pipefail
   conda install -y anaconda-client
   pkgs_to_upload=$(find "${CONDA_OUTPUT_DIR}" -name "*.tar.bz2")
 
+  export CONDA_ORG="${1}"
+
+  case "${CONDA_ORG}" in
+    "rapidsai")
+      TOKEN="${ANACONDA_STABLE_TOKEN}"
+      ;;
+    "rapidsai-nightly")
+      TOKEN="${ANACONDA_NIGHTLY_TOKEN}"
+      ;;
+    *)
+      echo "Unknown conda org: ${CONDA_ORG}"
+      exit 1
+      ;;
+  esac
+
+
   anaconda \
-    -t "${ANACONDA_TOKEN}" \
+    -t "${TOKEN}" \
     upload \
     --no-progress \
     ${pkgs_to_upload}
 } 1>&2
 
-jq -ncr '{name: "Conda release", url: "https://anaconda.org/rapidsai/rapids-dependency-file-generator"}'
+jq -ncr '{name: "Conda release - \(env.CONDA_ORG)", url: "https://anaconda.org/\(env.CONDA_ORG)/rapids-dependency-file-generator"}'


### PR DESCRIPTION
This PR updates the release scripts to ensure that DFG is uploaded to both the `rapidsai` and `rapidsai-nightly` Anaconda.org organizations.