### PR TITLE
chore(refactor): require keyword-only args in make_dependency_files()

### DIFF
--- a/src/rapids_dependency_file_generator/_cli.py
+++ b/src/rapids_dependency_file_generator/_cli.py
@@ -148,4 +148,11 @@ def main(argv=None):
     if args.clean:
         delete_existing_files(args.clean)
 
-    make_dependency_files(parsed_config, file_keys, output, matrix, args.prepend_channels, to_stdout)
+    make_dependency_files(
+        parsed_config=parsed_config,
+        file_keys=file_keys,
+        output=output,
+        matrix=matrix,
+        prepend_channels=args.prepend_channels,
+        to_stdout=to_stdout,
+    )

--- a/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
@@ -312,13 +312,14 @@ def should_use_specific_entry(matrix_combo: dict[str, str], specific_entry_matri
 
 
 def make_dependency_files(
+    *,
     parsed_config: _config.Config,
     file_keys: list[str],
     output: typing.Union[set[_config.Output], None],
     matrix: typing.Union[dict[str, list[str]], None],
     prepend_channels: list[str],
     to_stdout: bool,
-):
+) -> None:
     """Generate dependency files.
 
     This function iterates over data parsed from a YAML file conforming to the


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31.

Follow-up to https://github.com/rapidsai/rapids-build-backend/pull/17#discussion_r1576662655.

Proposes restricting `make_dependency_files()` to only accepting keyword arguments, to reduce the risk of oops-passed-this-in-the-wrong-order types of bugs, and to make code using it a little bit easier to read.

## Notes for Reviewers

The only direct usage of that function outside of this project itself is in `rapids-build-backend`, and that's already using keyword arguments in its one call ([GitHub search](https://github.com/search?q=org%3Arapidsai%20%22make_dependency_files%22&type=code) | [rapids-build-backend code link](https://github.com/rapidsai/rapids-build-backend/blob/97a19504201f18cfae1864c8be99c1d73cbcc0f9/rapids_build_backend/impls.py#L198)).

So this is safe to merge and shouldn't break anything.