### PR TITLE
fix: fix return type hint for dedupe()

### DIFF
--- a/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
@@ -41,7 +41,7 @@ def delete_existing_files(root: os.PathLike) -> None:
 
 def dedupe(
     dependencies: list[typing.Union[str, _config.PipRequirements]],
-) -> list[typing.Union[str, dict[str, list[str]]]]:
+) -> typing.Sequence[str | dict[str, list[str]]]:
     """Generate the unique set of dependencies contained in a dependency list.
 
     Parameters
@@ -51,7 +51,7 @@ def dedupe(
 
     Returns
     -------
-    list[str | dict[str, list[str]]]
+    Sequence[str | dict[str, list[str]]]
         The ``dependencies`` with all duplicates removed.
     """
     string_deps: set[str] = set()
@@ -65,7 +65,7 @@ def dedupe(
     if pip_deps:
         return [*sorted(string_deps), {"pip": sorted(pip_deps)}]
     else:
-        return sorted(string_deps)  # type: ignore[return-value]
+        return sorted(string_deps)
 
 
 def grid(gridspec: dict[str, list[str]]) -> Generator[dict[str, str]]:
@@ -99,7 +99,7 @@ def make_dependency_file(
     config_file: os.PathLike,
     output_dir: os.PathLike,
     conda_channels: list[str],
-    dependencies: list[typing.Union[str, dict[str, list[str]]]],
+    dependencies: typing.Sequence[typing.Union[str, dict[str, list[str]]]],
     extras: _config.FileExtras,
 ):
     """Generate the contents of the dependency file.
@@ -117,7 +117,7 @@ def make_dependency_file(
     conda_channels : list[str]
         The channels to include in the file. Only used when `file_type` is
         CONDA.
-    dependencies : list[str | dict[str, list[str]]]
+    dependencies : Sequence[str | dict[str, list[str]]]
         The dependencies to include in the file.
     extras : FileExtras
         Any extra information provided for generating this dependency file.

--- a/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
@@ -41,7 +41,7 @@ def delete_existing_files(root: os.PathLike) -> None:
 
 def dedupe(
     dependencies: list[typing.Union[str, _config.PipRequirements]],
-) -> typing.Sequence[str | dict[str, list[str]]]:
+) -> typing.Sequence[typing.Union[str, dict[str, list[str]]]]:
     """Generate the unique set of dependencies contained in a dependency list.
 
     Parameters

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -19,7 +19,7 @@ def test_dedupe():
     deduped = dedupe(["dep1", "dep1", "dep2"])
     assert deduped == ["dep1", "dep2"]
 
-    # list w/ pip dependencies
+    # list w/ mix of simple and pip dependencies
     deduped = dedupe(
         [
             "dep1",
@@ -29,6 +29,15 @@ def test_dedupe():
         ]
     )
     assert deduped == ["dep1", {"pip": ["pip_dep1", "pip_dep2"]}]
+
+    # list w/ only pip dependencies
+    deduped = dedupe(
+        [
+            _config.PipRequirements(pip=["pip_dep1", "pip_dep2"]),
+            _config.PipRequirements(pip=["pip_dep3", "pip_dep1"]),
+        ]
+    )
+    assert deduped == [{"pip": ["pip_dep1", "pip_dep2", "pip_dep3"]}]
 
 
 @mock.patch(


### PR DESCRIPTION
Contributes to #87.

`rapids-dependency-file-generator` handles deduplicating the sets of dependencies provided to it, including `pip: ` lists for conda environments.

This PR modifies the logic the function does that in the following ways:

* fixes return type hint
* refactors it so that:
   - only a single pass is done over the inputs to split requirements in to pip vs non-pip
   - assignments are done in a way that's a bit easier for a type checker to understand

This fixes these errors found by `mypy`:

```text
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:65: error: Argument 1 to "append" of "list" has incompatible type "dict[str, list[str]]"; expected "str"  [arg-type]
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:66: error: Incompatible return value type (got "list[str]", expected "list[str | dict[str, str]]")  [return-value]
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:66: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:66: note: Consider using "Sequence" instead, which is covariant
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:66: note: Perhaps you need a type annotation for "deduped"? Suggestion: "list[str | dict[str, str]]"
src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py:425: error: Argument "dependencies" to "make_dependency_file" has incompatible type "list[str | dict[str, str]]"; expected "list[str | dict[str, list[str]]]"  [arg-type]
```

## How I tested this

Confirmed that this behavior is covered by existing unit tests (and added one more condition there for completeness).

Ran the following to confirm that some of the `mypy` issues had been resolved:

```shell
mypy \
    --ignore-missing-imports \
    --explicit-package-bases \
    ./src
```