### PR TITLE
chore(refactor): add a py.typed file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include src/rapids_dependency_file_generator/py.typed
 include src/rapids_dependency_file_generator/schema.json


### PR DESCRIPTION
Contributes to #76 and #87.

Proposes adding a `py.typed` file, to advertise to type-checkers that this project contains inline type hints (i.e. doesn't ship a separate package of type stubs).

This is described in PEP 561: https://peps.python.org/pep-0561/

> *Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing.*

This didn't really matter when `rapids-dependency-file-generator` was only being used as a CLI, but now that `rapids-build-backend` is consuming it as a library, I think this is useful to have. It means that `mypy`, `pyright`, etc. used to check `rapids-build-backend` will also consider `rapids_dependency_file_generator`'s type hints.

## How I tested this

Built a wheel and confirmed that this file made it in with my `MANIFEST.in` changes here.

```shell
python -m build .
unzip -l ./dist/rapids_dependency_file_generator-1.13.5-py3-none-any.whl
```