### PR TITLE
chore(refactor): prefer typing.Any to 'object' for type hints

### DIFF
--- a/src/rapids_dependency_file_generator/_config.py
+++ b/src/rapids_dependency_file_generator/_config.py
@@ -158,7 +158,7 @@ def _parse_extras(extras: dict[str, str]) -> FileExtras:
     )
 
 
-def _parse_file(file_config: dict[str, object]) -> File:
+def _parse_file(file_config: dict[str, typing.Any]) -> File:
     def get_extras():
         try:
             extras = file_config["extras"]
@@ -185,7 +185,7 @@ def _parse_requirement(requirement: typing.Union[str, dict[str, list[str]]]) -> 
     return PipRequirements(pip=requirement["pip"])
 
 
-def _parse_dependencies(dependencies: dict[str, object]) -> Dependencies:
+def _parse_dependencies(dependencies: dict[str, typing.Any]) -> Dependencies:
     return Dependencies(
         common=[
             CommonDependencies(
@@ -217,12 +217,12 @@ def _parse_channels(channels) -> list[str]:
     return list(channels)
 
 
-def parse_config(config: dict[str, object], path: PathLike) -> Config:
+def parse_config(config: dict[str, typing.Any], path: PathLike) -> Config:
     """Parse a configuration file from a dictionary.
 
     Parameters
     ----------
-    config : dict[str, object]
+    config : dict[str, Any]
         The dictionary to parse.
     path : PathLike
         The path to the parsed configuration file. This will be stored as the ``path``


### PR DESCRIPTION
Contributes to #87.

Proposes changing type hints using `object` to `typing.Any`.

This fixes 10 errors from `mypy`.

<details><summary>full list (click me)</summary>

```text
src/rapids_dependency_file_generator/_config.py:171: error: Argument 1 to "_parse_outputs" has incompatible type "object"; expected "Union[str, list[str]]"  [arg-type]
src/rapids_dependency_file_generator/_config.py:173: error: No overload variant of "list" matches argument type "object"  [call-overload]
src/rapids_dependency_file_generator/_config.py:173: note: Possible overload variants:
src/rapids_dependency_file_generator/_config.py:173: note:     def [_T] list(self) -> list[_T]
src/rapids_dependency_file_generator/_config.py:173: note:     def [_T] list(self, Iterable[_T], /) -> list[_T]
src/rapids_dependency_file_generator/_config.py:174: error: "object" has no attribute "items"  [attr-defined]
src/rapids_dependency_file_generator/_config.py:175: error: Argument 1 to "Path" has incompatible type "object"; expected "Union[str, PathLike[str]]"  [arg-type]
src/rapids_dependency_file_generator/_config.py:176: error: Argument 1 to "Path" has incompatible type "object"; expected "Union[str, PathLike[str]]"  [arg-type]
src/rapids_dependency_file_generator/_config.py:177: error: Argument 1 to "Path" has incompatible type "object"; expected "Union[str, PathLike[str]]"  [arg-type]
src/rapids_dependency_file_generator/_config.py:195: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]
src/rapids_dependency_file_generator/_config.py:208: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]
src/rapids_dependency_file_generator/_config.py:244: error: "object" has no attribute "items"  [attr-defined]
src/rapids_dependency_file_generator/_config.py:246: error: "object" has no attribute "items"  [attr-defined]
```

</details>

## Notes for Reviewers

### What's the difference between `object` and `typing.Any`?

I'll let the `typing` docs explain:

> _This behavior allows `Any` to be used as an escape hatch when you need to mix dynamically and statically typed code._
>
> _Contrast the behavior of `Any` with the behavior of `object`. Similar to `Any`, every type is a subtype of `object`._
> _However, **unlike `Any` ... `object` is not a subtype of every other type.**_

([docs link](https://docs.python.org/3/library/typing.html#the-any-type))

This is why with a type hint like `object` you get errors like this:

```text
_config.py:244: error: "object" has no attribute "items"
```

`typing.Any` tells the type checker "just ignore this object from this point on in the stack".

### Shouldn't we use a more specific type than `typing.Any`?

I don't think so.

These hints with `typing.Any` are only in the parts of the codebase taking in mostly-unstructured data read in with `yaml.load()`. Those functions (`parse_config()` and the things it calls) are taking on the responsibility of imposing structure and are the only place working with the raw dictionary representation of the YAML.

I think it's fairly low-risk to use `typing.Any` in that situation and simpler than, say, creating a type alias with a union of all the types that `yaml.load()` could produce in its dictionary representation of the YAML.

`pyyaml`'s own type stubs use `typing.Any` for the return value of `safe_load()`: https://github.com/python/typeshed/blob/a9d7e861f7a46ae7acd56569326adef302e10f29/stubs/PyYAML/yaml/__init__.pyi#L38.