### PR TITLE
fix: raise informative error if 'extras' key is missing for pyproject files

### DIFF
--- a/src/rapids_dependency_file_generator/_config.py
+++ b/src/rapids_dependency_file_generator/_config.py
@@ -159,7 +159,7 @@ def _parse_extras(extras: dict[str, str]) -> FileExtras:
 
 
 def _parse_file(file_config: dict[str, typing.Any]) -> File:
-    def get_extras():
+    def get_extras() -> typing.Union[FileExtras, None]:
         try:
             extras = file_config["extras"]
         except KeyError:

--- a/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
+++ b/src/rapids_dependency_file_generator/_rapids_dependency_file_generator.py
@@ -100,7 +100,7 @@ def make_dependency_file(
     output_dir: os.PathLike,
     conda_channels: list[str],
     dependencies: typing.Sequence[typing.Union[str, dict[str, list[str]]]],
-    extras: _config.FileExtras,
+    extras: typing.Union[_config.FileExtras, None],
 ):
     """Generate the contents of the dependency file.
 
@@ -119,7 +119,7 @@ def make_dependency_file(
         CONDA.
     dependencies : Sequence[str | dict[str, list[str]]]
         The dependencies to include in the file.
-    extras : FileExtras
+    extras : FileExtras | None
         Any extra information provided for generating this dependency file.
 
     Returns
@@ -145,17 +145,20 @@ def make_dependency_file(
     elif file_type == _config.Output.REQUIREMENTS:
         file_contents += "\n".join(dependencies) + "\n"
     elif file_type == _config.Output.PYPROJECT:
+        if extras is None:
+            raise ValueError("The 'extras' field must be provided for the 'pyproject' file type.")
+
         if extras.table == "build-system":
             key = "requires"
             if extras.key is not None:
                 raise ValueError(
-                    "The 'key' field is not allowed for the 'pyproject' file type when " "'table' is 'build-system'."
+                    "The 'key' field is not allowed for the 'pyproject' file type when 'table' is 'build-system'."
                 )
         elif extras.table == "project":
             key = "dependencies"
             if extras.key is not None:
                 raise ValueError(
-                    "The 'key' field is not allowed for the 'pyproject' file type when " "'table' is 'project'."
+                    "The 'key' field is not allowed for the 'pyproject' file type when 'table' is 'project'."
                 )
         else:
             if extras.key is None:

--- a/tests/examples/pyproject-no-extras/dependencies.yaml
+++ b/tests/examples/pyproject-no-extras/dependencies.yaml
@@ -1,0 +1,12 @@
+files:
+  beep_boop:
+    output: pyproject
+    includes:
+      - run_deps
+    pyproject_dir: .
+dependencies:
+  run_deps:
+    common:
+      - output_types: [pyproject]
+        packages:
+          - fsspec>=0.6.0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,7 @@ _erroneous_examples = [
     "no-specific-match",
     "pyproject_matrix_multi",
     "pyproject_bad_key",
+    "pyproject-no-extras",
 ]
 EXAMPLE_FILES = [
     pth

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -3,6 +3,7 @@ from unittest import mock
 import yaml
 import tomlkit
 import pathlib
+import pytest
 
 from rapids_dependency_file_generator import _config
 from rapids_dependency_file_generator._constants import cli_name
@@ -77,6 +78,20 @@ def test_make_dependency_file(mock_relpath):
         extras=None,
     )
     assert env == header + "dep1\ndep2\n"
+
+
+def test_make_dependency_file_should_raise_informative_error_when_extras_is_missing_for_pyproj():
+
+    current_dir = pathlib.Path(__file__).parent
+    with pytest.raises(ValueError, match=r"The 'extras' field must be provided for the 'pyproject' file type"):
+        make_dependency_files(
+            parsed_config=_config.load_config_from_file(current_dir / "examples" / "pyproject-no-extras" / "dependencies.yaml"),
+            file_keys=["beep_boop"],
+            output={_config.Output.PYPROJECT},
+            matrix=None,
+            prepend_channels=[],
+            to_stdout=True
+        )
 
 
 def test_make_dependency_files_should_choose_correct_pyproject_toml(capsys):


### PR DESCRIPTION
Contributes to #87.

`mypy` caught some code that's treating `File.extras` as if it's unconditionally not `None`, when it actually can be `None`.

```text
_rapids_dependency_file_generator.py:426: error: Argument "extras" to "make_dependency_file" has incompatible type "FileExtras | None"; expected "FileExtras"  [arg-type]
```

This fixes that by correcting some types hints and explicitly raising an error if a `None` makes it to the part of `make_dependency_file()` where that `extras` field is nedeed.

Prior to this change, given a `dependencies.yaml` like this:

```yaml
files:
  beep_boop:
    output: pyproject
    includes:
      - run_deps
    pyproject_dir: .
dependencies:
  run_deps:
    common:
      - output_types: [pyproject]
        packages:
          - fsspec>=0.6.0
```

`rapids-dependency-file-generator` would raise an error like this:

```text
Traceback (most recent call last):
...
AttributeError: 'NoneType' object has no attribute 'table'
```

As of this change, the error is more informative and requires less knowledge of the `rapids-dependency-file-generator` internals:

```text
Traceback (most recent call last):
...
ValueError: The 'extras' field must be provided for the 'pyproject' file type.
```