### PR TITLE
test: add tests on handling of duplicate matrix selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ The `--file-key` argument is passed the `test` key name from the `files` configu
 
 The `--file-key`, `--output`, and `--matrix` flags must be used together. `--matrix` may be an empty string if the file that should be generated does not depend on any specific matrix variations.
 
+Where multiple values for the same key are passed to `--matrix`, e.g. `cuda_suffixed=true;cuda_suffixed=false`, only the last value will be used.
+
 The `--prepend-channel` argument accepts additional channels to use, like `rapids-dependency-file-generator --prepend-channel my_channel --prepend-channel my_other_channel`.
 If both `--output` and `--prepend-channel` are provided, the output format must be conda.
 Prepending channels can be useful for adding local channels with packages to be tested in CI workflows.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,16 @@ def test_generate_matrix():
     assert matrix is None
 
 
+def test_generate_matrix_allows_duplicates_and_chooses_the_final_value():
+    # duplicate keys
+    matrix = generate_matrix("thing=abc;other_thing=true;thing=def;thing=ghi")
+    assert matrix == {"other_thing": ["true"], "thing": ["ghi"]}
+
+    # duplicate keys and values
+    matrix = generate_matrix("thing=abc;thing=abc")
+    assert matrix == {"thing": ["abc"]}
+
+
 def test_validate_args():
     # Missing output
     with pytest.raises(Exception):
@@ -104,5 +114,19 @@ def test_validate_args():
             "my_channel",
             "--prepend-channel",
             "my_other_channel",
+        ]
+    )
+
+    # Valid, with duplicates in --matrix
+    validate_args(
+        [
+            "-c",
+            "dependencies2.yaml",
+            "--output",
+            "pyproject",
+            "--matrix",
+            "cuda_suffixed=true;arch=x86_64;cuda_suffixed=false",
+            "--file-key",
+            "all",
         ]
     )


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31.

Over in https://github.com/rapidsai/devcontainers/pull/365, I'm proposing a change that depends on how `rapids-dependency-file-generator` handles duplicates in `--matrix` selectors.

See https://github.com/rapidsai/devcontainers/pull/365#discussion_r1687121294.

This proposes adding tests covering that behavior, to reduce the risk of accidentally removing that support in future refactorings.