### PR TITLE
chore(refactor): update pre-commit hook verions, pyupgrade target Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,20 +11,20 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.0'
+    rev: 'v1.11.2'
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML]
         args: ["--config-file=pyproject.toml", "src/", "docs/"]
         pass_filenames: false
   - repo: https://github.com/asottile/pyupgrade
-    rev: 'v3.15.2'
+    rev: 'v3.17.0'
     hooks:
       - id: pyupgrade
         args:
-          - --py38-plus
+          - --py39-plus
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.3
+    rev: 0.29.2
     hooks:
         - id: check-metaschema
           files: ^src/rapids_dependency_file_generator/schema.json$
@@ -33,7 +33,7 @@ repos:
           args: ["--schemafile", "src/rapids_dependency_file_generator/schema.json"]
         - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.6.2
     hooks:
       - id: ruff
         files: src/.*$


### PR DESCRIPTION
This project supports `python>=3.9`

https://github.com/rapidsai/dependency-file-generator/blob/4e32ded33b3df70e88cff06bac59488fca74ae7f/pyproject.toml#L21

But is telling `pyupgrade` it supports `python>=3.8`.

https://github.com/rapidsai/dependency-file-generator/blob/4e32ded33b3df70e88cff06bac59488fca74ae7f/.pre-commit-config.yaml#L22-L25

This fixes that, and updates all the other hook versions (`pre-commit autoupdate`) since it's been a while.

## Notes for Reviewers

### Shouldn't we upgrade the floor to `requires-python = >= 3.10`?

I don't think so. That's being done across RAPIDS libraries in https://github.com/rapidsai/build-planning/issues/88 right now, but `rapids-dependency-file-generator` is used in many places outside of RAPIDS (see everything linked to https://github.com/rapidsai/dependency-file-generator/issues/89, for example).

For tools like this, I think we should generally support a wider range of Python versions than RAPIDS itself does.