### PR TITLE
chore(deps): require python-build in conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 requirements:
   host:
     - python >=3.9
-    - build
+    - python-build
   run:
     - python >=3.9
     - pyyaml


### PR DESCRIPTION
I saw conda builds in CI on #106 failing like this:

```text
Traceback (most recent call last):
  File "/opt/conda/bin/conda-mambabuild", line 10, in <module>
 - python >=3.9
 - build

with channels:

The reported errors are:
- Encountered problems while solving:
-   - nothing provides requested build
```

Looks to me like this is due to the following set of circumstances:

* the conda package here has a dependency on `build`
* conda-forge stopped publishing it 2 years ago: https://github.com/conda-forge/build-feedstock

This fixes that by switching the dependency in the recipe from `build` to `python-build`.

## Notes for Reviewers

I'm really not sure why this is just breaking now... the latest release of `build` at https://anaconda.org/conda-forge/build/files is a noarch package without any constraints that appear to conflict with other things we're installing here.

`python-build` is what we want either way, since it's being actively updated, but would be good to understand why this just broke now.

I checked across the `rapidsai` org and don't see any other cases where we were relying on the old `build` package: https://github.com/search?q=org%3Arapidsai+%22-+build%22+language%3AYAML+path%3Ameta.yaml&type=code