### PR TITLE
chore(refactor): Search for `.conda` packages to upload too

### DIFF
--- a/ci/publish/conda.sh
+++ b/ci/publish/conda.sh
@@ -9,7 +9,7 @@ set -euo pipefail
   . /usr/share/miniconda/etc/profile.d/conda.sh
   conda activate base
   conda install -y anaconda-client
-  pkgs_to_upload=$(find "${CONDA_OUTPUT_DIR}" -name "*.tar.bz2")
+  pkgs_to_upload=$(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")
 
   export CONDA_ORG="${1}"
 


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/98

Uses [`find`]( https://www.man7.org/linux/man-pages/man1/find.1p.html )'s `-o` option to search for `.conda` or `.tar.bz2` files to upload

Once collected the `anaconda upload` command later should take care of the rest