### PR TITLE
fix: add host dependency on 'setuptools', ignore renovate Python updates

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   host:
     - python >=3.9
     - python-build
+    - setuptools
   run:
     - python >=3.9
     - pyyaml

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "ignoreDeps": [
+    "python"
+  ]
 }


### PR DESCRIPTION
The `renovate` bot just opened #112, trying to upgrade the CI image used in this repo for wheel builds / tests from `python:3.9` to `python:3.13`.

 We don't want those types of updates... it's an intentional choice that `rapids-dependency-file-generator` wheels are built and tested on the oldest Python version this tool supports.

This PR attempts to tell `renovate` not to make such recommendations in the future. I saw "attempts" because I have no idea how to test this.

references suggesting this `ignoreDeps` field is the right way to do this:

* https://docs.renovatebot.com/configuration-options/#ignoredeps
* https://github.com/rapidsai/docker/pull/643#issuecomment-2168645396