### PR TITLE
fix(docs): Move developer specific docs from `README.md` to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,16 @@ If a change type not listed in the table above is used, it will not trigger a re
 The source of truth for these rules is [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer). The `angular` preset is used by default, which is documented [here](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
 
 [semantic-release]: https://github.com/semantic-release/semantic-release
+
+## Examples
+
+The [tests/examples](./tests/examples/) directory has example `dependencies.yaml` files along with their corresponding output files.
+
+To create new `example` tests do the following:
+
+- Create a new directory with a `dependencies.yaml` file in [tests/examples](tests/examples/)
+- Ensure the `output` directories (e.g. `conda_dir`, `requirements_dir`, etc.) are set to write to `output/actual`
+- Run `rapids-dependency-file-generator --config tests/examples/<new_folder_name>/dependencies.yaml` to generate the initial output files
+- Manually inspect the generated files for correctness
+- Copy the contents of `output/actual` to `output/expected`, so it will be committed to the repository and used as a baseline for future changes
+- Add the new folder name to [test_examples.py](./tests/test_examples.py)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,4 @@ To create new `example` tests do the following:
 - Manually inspect the generated files for correctness
 - Copy the contents of `output/actual` to `output/expected`, so it will be committed to the repository and used as a baseline for future changes
 - Add the new folder name to [test_examples.py](./tests/test_examples.py)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,3 @@ To create new `example` tests do the following:
 - Manually inspect the generated files for correctness
 - Copy the contents of `output/actual` to `output/expected`, so it will be committed to the repository and used as a baseline for future changes
 - Add the new folder name to [test_examples.py](./tests/test_examples.py)
-

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `dependencies.yaml` file has the following characteristics:
 
 - it is intended to be committed to the root directory of repositories
 - it can define matrices that enable the output dependency files to vary according to any arbitrary specification (or combination of specifications), including CUDA version, machine architecture, Python version, etc.
-- it contains bifurcated lists of dependencies based on the dependency's purpose (i.e. build, runtime, test, etc.). The bifurcated dependency lists are merged according to the description in the [_How Dependency Lists Are Merged_](#how-dependency-lists-are-merged) section below.
+- it contains bifurcated lists of dependencies based on the dependency's purpose (i.e. build, runtime, test, etc.). The bifurcated dependency lists are merged according to the description in the _"How Dependency Lists Are Merged"_ section below.
 
 ## `dependencies.yaml` Format
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@
 
 When installed, it makes the `rapids-dependency-file-generator` CLI command available which is responsible for parsing a `dependencies.yaml` configuration file and generating the appropriate conda `environment.yaml` and `requirements.txt` dependency files.
 
-## Table of Contents
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [`dependencies.yaml` Format](#dependenciesyaml-format)
-  - [`files` key](#files-key)
-  - [`channels` key](#channels-key)
-  - [`dependencies` key](#dependencies-key)
-- [How Dependency Lists Are Merged](#how-dependency-lists-are-merged)
-- [Additional CLI Notes](#additional-cli-notes)
-- [Examples](#examples)
-
 ## Installation
 
 `rapids-dependency-file-generator` is available on [PyPI](https://pypi.org/project/rapids-dependency-file-generator/). To install, run:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In the absence of a `channels` key, some sensible defaults for RAPIDS will be us
 
 The top-level `dependencies` key is where the bifurcated dependency lists should be specified.
 
-Underneath the `dependencies` key are sets of key-value pairs. For each pair, the key can be arbitarily named, but should match an item from the `includes` list of any `files` entry.
+Underneath the `dependencies` key are sets of key-value pairs. For each pair, the key can be arbitrarily named, but should match an item from the `includes` list of any `files` entry.
 
 The value of each key-value pair can have the following children keys:
 
@@ -350,16 +350,3 @@ If both `--output` and `--prepend-channel` are provided, the output format must 
 Prepending channels can be useful for adding local channels with packages to be tested in CI workflows.
 
 Running `rapids-dependency-file-generator -h` will show the most up-to-date CLI arguments.
-
-## Examples
-
-The [tests/examples](./tests/examples/) directory has example `dependencies.yaml` files along with their corresponding output files.
-
-To create new `example` tests do the following:
-
-- Create a new directory with a `dependencies.yaml` file in [tests/examples](tests/examples/)
-- Ensure the `output` directories (e.g. `conda_dir`, `requirements_dir`, etc.) are set to write to `output/actual`
-- Run `rapids-dependency-file-generator --config tests/examples/<new_folder_name>/dependencies.yaml` to generate the initial output files
-- Manually inspect the generated files for correctness
-- Copy the contents of `output/actual` to `output/expected`, so it will be committed to the repository and used as a baseline for future changes
-- Add the new folder name to [test_examples.py](./tests/test_examples.py)

--- a/README.md
+++ b/README.md
@@ -338,3 +338,4 @@ If both `--output` and `--prepend-channel` are provided, the output format must 
 Prepending channels can be useful for adding local channels with packages to be tested in CI workflows.
 
 Running `rapids-dependency-file-generator -h` will show the most up-to-date CLI arguments.
+

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ The `dependencies.yaml` file has the following characteristics:
 
 ## `dependencies.yaml` Format
 
-> The [Examples](#examples) section below has instructions on where example `dependency.yaml` files and their corresponding output can be viewed.
-
 The `dependencies.yaml` file has three relevant top-level keys: `files`, `channels`, and `dependencies`. These keys are described in detail below.
 
 ### `files` Key

--- a/README.md
+++ b/README.md
@@ -338,4 +338,3 @@ If both `--output` and `--prepend-channel` are provided, the output format must 
 Prepending channels can be useful for adding local channels with packages to be tested in CI workflows.
 
 Running `rapids-dependency-file-generator -h` will show the most up-to-date CLI arguments.
-


### PR DESCRIPTION
* Move the section regarding the test examples to `CONTRIBUTING.md`, this information is developer specific and resulted in broken links on pypi.org
* Remove the table of contents, as the anchor tags were similarly broken on pypi.org
* Misc spelling error fix.

Closes #121