### PR TITLE
Replace `conda-mambabuild` with `conda-build`

### DIFF
--- a/ci/build-test/conda.sh
+++ b/ci/build-test/conda.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ./ci/update-versions.sh "${RELEASE_VERSION:-}"
 
-mamba install -y boa conda-build
-conda mambabuild \
+mamba install -y conda-build
+conda build \
   --output-folder "${OUTPUT_DIR:-"/tmp/output"}" \
   recipe/


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149