### PR TITLE
fix: force usage of newer `twine` and `packaging` and wheels CI

### DIFF
--- a/ci/build-test/wheel.sh
+++ b/ci/build-test/wheel.sh
@@ -11,7 +11,7 @@ python -m build \
   --outdir "${OUTPUT_DIR}" \
   .
 
-twine check --strict "$(echo "${OUTPUT_DIR}"/*.whl)"
+twine check --strict "$(echo "${OUTPUT_DIR}"/*)"
 
 for PKG in "${OUTPUT_DIR}/"*; do
   echo "$PKG"

--- a/ci/build-test/wheel.sh
+++ b/ci/build-test/wheel.sh
@@ -5,7 +5,7 @@ OUTPUT_DIR="${OUTPUT_DIR:-"/tmp/output"}"
 
 ./ci/update-versions.sh "${RELEASE_VERSION:-}"
 
-pip install build pytest twine
+pip install build pytest 'packaging>=24.2' 'twine>=6.1.0'
 
 python -m build \
   --outdir "${OUTPUT_DIR}" \

--- a/ci/build-test/wheel.sh
+++ b/ci/build-test/wheel.sh
@@ -5,11 +5,13 @@ OUTPUT_DIR="${OUTPUT_DIR:-"/tmp/output"}"
 
 ./ci/update-versions.sh "${RELEASE_VERSION:-}"
 
-pip install build pytest
+pip install build pytest twine
 
 python -m build \
   --outdir "${OUTPUT_DIR}" \
   .
+
+twine check --strict "$(echo "${OUTPUT_DIR}"/*.whl)"
 
 for PKG in "${OUTPUT_DIR}/"*; do
   echo "$PKG"

--- a/ci/publish/wheel.sh
+++ b/ci/publish/wheel.sh
@@ -6,7 +6,9 @@
 set -euo pipefail
 
 {
-  pip install twine
+  pip install \
+    'packaging>=24.2' \
+    'twine>=6.1.0'
 
   twine upload \
     --username __token__ \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 urls = { homepage = "https://github.com/rapidsai/dependency-file-generator" }
 description = "Tool for generating RAPIDS environment files"
 readme = { file = "README.md", content-type = "text/markdown" }
-license = { text = "Apache-2.0" }
+license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 urls = { homepage = "https://github.com/rapidsai/dependency-file-generator" }
 description = "Tool for generating RAPIDS environment files"
 readme = { file = "README.md", content-type = "text/markdown" }
-license = { file = "LICENSE" }
+license = { text = "Apache-2.0" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
After merging #130 , the release job for v1.18.0 failed like this:

> Uploading distributions to https://upload.pypi.org/legacy/\n](https://upload.pypi.org/legacy/
>   InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'

([build link](https://github.com/rapidsai/dependency-file-generator/actions/runs/13845385771/job/38742653435#step:5:956))

It looks like this is caused by using a new `twine` with a too-old `packaging`: https://github.com/pypa/twine/issues/1216#issuecomment-2629069669

This PR proposes:

* putting floors on those libraries in wheels CI
* running `twine check --strict` in CI (to hopefully catch issues like this before releases)

## Notes for Reviewers

Prefixing the title with `fix:` to intentionally generate a `v1.18.1`... I want to see a new release get triggered, to confirm this actually worked.