### PR TITLE
chore(ci): update pre-commit.ci commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_commit_msg: "chore(ci): pre-commit auto fixes"
+  autoupdate_commit_msg: "chore(ci): pre-commit autoupdate"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 'v4.6.0'


### PR DESCRIPTION
This project enforces some conventions on commit messages (including PR titles, which become commit messages on squash-merge), which are used to automate versioning.

The automatic `pre-commit.ci` PRs like #133 don't currently generate titles that comply with that (I manually changed the title of that one to get it working).

This proposes modifying the configuration for that service, so its PRs will be mergeable without manual renaming effort. For reference, see https://pre-commit.ci/#configuration