### PR TITLE
chore(ci): add shellcheck to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,10 @@ repos:
         files: src/.*$
       - id: ruff-format
         files: src/.*$
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
 default_language_version:
     python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,5 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
-        args: ["--severity=warning"]
 default_language_version:
     python: python3

--- a/ci/publish/conda.sh
+++ b/ci/publish/conda.sh
@@ -6,10 +6,11 @@
 set -euo pipefail
 
 {
+  # shellcheck disable=SC1091
   . /usr/share/miniconda/etc/profile.d/conda.sh
   conda activate base
   conda install -y anaconda-client
-  pkgs_to_upload=$(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")
+  readarray -d '' pkgs_to_upload < <(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")
 
   export CONDA_ORG="${1}"
 
@@ -31,7 +32,7 @@ set -euo pipefail
     -t "${TOKEN}" \
     upload \
     --no-progress \
-    ${pkgs_to_upload}
+    "${pkgs_to_upload[@]}"
 } 1>&2
 
 jq -ncr '{name: "Conda release - \(env.CONDA_ORG)", url: "https://anaconda.org/\(env.CONDA_ORG)/rapids-dependency-file-generator"}'


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these warnings:

```text
SC1091 (info): Not following: /usr/share/miniconda/etc/profile.d/conda.sh was not specified as input (see shellcheck -x).
SC2086 (info): Double quote to prevent globbing and word splitting.
```

Also updates all other hooks with `pre-commit autoupdate`.