### PR TITLE
chore(ci): use 'matplotlib-base' instead of 'matplotlib' in conda examples

### DIFF
--- a/tests/examples/overlapping-deps/dependencies.yaml
+++ b/tests/examples/overlapping-deps/dependencies.yaml
@@ -57,12 +57,13 @@ dependencies:
           - scikit-learn>=1.5
   test_python:
     common:
-      - output_types: [conda, requirements, pyproject]
+      - output_types: [requirements, pyproject]
         packages:
           - matplotlib
       - output_types: [conda]
         packages:
           - pip
+          - matplotlib-base
           # intentional overlap (numpy) with depends_on_numpy's pip list, to
           # test that pip dependencies don't have duplicates
           - pip:

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -198,6 +198,7 @@ def test_make_dependency_files_conda_to_stdout_with_multiple_file_keys_works(cap
         "scikit-learn>=1.5",
         {"pip": [
             "folium",
+            "matplotlib",
             "numpy>=2.0",
         ]}
     ]

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -192,7 +192,7 @@ def test_make_dependency_files_conda_to_stdout_with_multiple_file_keys_works(cap
     #  * should contain the union of all dependencies from all requested file keys
     #
     assert env_dict["dependencies"] == [
-        "matplotlib",
+        "matplotlib-base",
         "pandas<3.0",
         "pip",
         "scikit-learn>=1.5",

--- a/tests/test_rapids_dependency_file_generator.py
+++ b/tests/test_rapids_dependency_file_generator.py
@@ -198,7 +198,6 @@ def test_make_dependency_files_conda_to_stdout_with_multiple_file_keys_works(cap
         "scikit-learn>=1.5",
         {"pip": [
             "folium",
-            "matplotlib",
             "numpy>=2.0",
         ]}
     ]


### PR DESCRIPTION
When installing Matplotlib with Conda, use `matplotlib-base`. This is more lightweight as it doesn't pull in a bunch of GUI bits that we don't use.

ref: https://conda-forge.org/docs/maintainer/knowledge_base/#matplotlib