### PR TITLE
fix(ci): revert method of finding conda packages to upload

### DIFF
--- a/ci/publish/conda.sh
+++ b/ci/publish/conda.sh
@@ -10,7 +10,7 @@ set -euo pipefail
   . /usr/share/miniconda/etc/profile.d/conda.sh
   conda activate base
   conda install -y anaconda-client
-  readarray -d '' pkgs_to_upload < <(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")
+  pkgs_to_upload=$(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")
 
   export CONDA_ORG="${1}"
 
@@ -26,7 +26,6 @@ set -euo pipefail
       exit 1
       ;;
   esac
-
 
   anaconda \
     -t "${TOKEN}" \


### PR DESCRIPTION
Contributes to #143 

There, I noticed that when `anaconda upload` was complaining about a file not existing, it was breaking the log message onto 2 lines like this:

```text
Error:  File "/tmp/conda_output/noarch/rapids-dependency-file-generator-1.19.0-py_0.conda
" does not exist
```

That made me think "maybe an extra newline is getting in there".

I'm confident now that that's exactly what's happening. I think the changes in #139 switching from `find` to `readarray` introduced a trailing newline into the list of packages fed to `anaconda upload`, similar to what's described here: https://unix.stackexchange.com/questions/519914/how-to-remove-new-line-added-by-readarray-when-using-a-delimiter

We didn't catch that because merging that PR didn't trigger a release.

This PR:

* reverts to the previous, working logic with `find`
* uses a commit message with `fix()` so that merging this will trigger a new release (to test) 

## Notes for Reviewers

### How I tested this

Tested locally and saw that that `readarray` approach added a newline.

```shell
mkdir delete-me
touch delete-me/a.conda
touch delete-me/b.conda
touch delete-me/a.tar.bz2
touch delete-me/a.tar.bz222222

CONDA_OUTPUT_DIR=$(pwd)/delete-me

readarray -d '' pkgs_to_upload < <(find "${CONDA_OUTPUT_DIR}" -name "*.conda" -o -name "*.tar.bz2")

echo "${pkgs_to_upload[@]}"
```

prints:

```text
/home/jlamb/repos/dependency-file-generator/delete-me/b.conda
/home/jlamb/repos/dependency-file-generator/delete-me/a.tar.bz2
/home/jlamb/repos/dependency-file-generator/delete-me/a.conda

```

The `find` approach omits that trailing empty line.
