### PR TITLE
chore(ci): reduce pre-commit autoupdate frequency to quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autofix_commit_msg: "chore(ci): pre-commit auto fixes"
   autoupdate_commit_msg: "chore(ci): pre-commit autoupdate"
+  autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 'v6.0.0'


### PR DESCRIPTION
By default, `pre-commit.ci` checks for updates once a week.

This project uses some very actively-developed hooks, like `ruff`, meaning we get a PR like #160 almost every week.

This proposes reducing that check frequency to `quarterly`, to reduce the volume of notifications from this project.