### PR TITLE
chore(packaging): enforce wheel size limits, PEP 639 metadata

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-select = E,F,W
-ignore = E123,E126,E203,E226,E241,E704,W503,W504

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,13 @@ __pycache__
 *.egg-info
 dist
 build
+.mypy_cache
+.ruff_cache
 tests/**/actual
 .vscode
 *.swp
 node_modules
 docs/source/api_docs/generated/
+*.tar.gz
+*.whl
+*.zip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,5 +47,12 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v1.3.3
+    hooks:
+      - id: verify-pyproject-license
+        exclude:
+          (?x)
+            ^tests/.*$
 default_language_version:
     python: python3

--- a/ci/build-test/wheel.sh
+++ b/ci/build-test/wheel.sh
@@ -5,11 +5,18 @@ OUTPUT_DIR="${OUTPUT_DIR:-"/tmp/output"}"
 
 ./ci/update-versions.sh "${RELEASE_VERSION:-}"
 
-pip install build pytest 'packaging>=24.2' 'twine>=6.1.0'
+pip install build pytest \
+  'packaging>=24.2' \
+  'pydistcheck>=0.11.3' \
+  'twine>=6.1.0'
 
 python -m build \
   --outdir "${OUTPUT_DIR}" \
   .
+
+pydistcheck \
+  --inspect \
+  "${OUTPUT_DIR}"/*
 
 twine check --strict "${OUTPUT_DIR}"/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,14 @@ profile = "black"
 [tool.mypy]
 ignore_missing_imports = true
 
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+
+# PyPI hard limit is 1GiB, but try to keep this as small as possible
+max_allowed_size_compressed = '2Mi'
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
## Description

Proposes a batch of miscellaneous build / packaging / CI changes.

## Changes

### Adds size limit enforcement

Contributes to https://github.com/rapidsai/build-planning/issues/219

* adds package-size checks with `pydistcheck`

### Enforces PEP 639 license metadata in `pyproject.toml`

Contributes to https://github.com/rapidsai/pre-commit-hooks/issues/95

### Other misc. changes

* expands `.gitignore`
* removes unused `.flake8` file