### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/actions/semantic-release/action.yaml
+++ b/.github/actions/semantic-release/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: lts/*
     - name: Run Semantic Release

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     container: condaforge/miniforge3:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - run: ./ci/build-test/conda.sh
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conda_artifacts
           path: ${{ env.OUTPUT_DIR }}
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.9
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - run: ./ci/build-test/wheel.sh
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel_artifacts
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   OUTPUT_DIR: /tmp/output
-
+permissions: {}
 jobs:
   conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,7 @@ on:
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   build-test:
     uses: ./.github/workflows/build-test.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ concurrency:
   # release since that could cause issues
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
-
+permissions: {}
 jobs:
   check-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       release_version: ${{ steps.check-release.outputs.release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -41,17 +41,17 @@ jobs:
       WHEEL_OUTPUT_DIR: /tmp/wheel_output
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Download Conda Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: conda_artifacts
           path: ${{ env.CONDA_OUTPUT_DIR }}
       - name: Download Wheel Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wheel_artifacts
           path: ${{ env.WHEEL_OUTPUT_DIR }}

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -1,6 +1,10 @@
 name: pr-title
 
-on:
+# `zizmor` always flags these triggers because they are easy to use
+# incorrectly. This usage doesn't execute any PR specific code, it
+# only confirms that the PR title conforms to conventional commits
+# and so can be run from a forked PR.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened
@@ -10,6 +14,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   semantic-pr-title:

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -15,6 +15,6 @@ jobs:
   semantic-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,5 +54,9 @@ repos:
         exclude:
           (?x)
             ^tests/.*$
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 default_language_version:
     python: python3


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275