### PR TITLE
feat: add renovate cooldown period

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": [
+    "config:recommended"
+  ],
   "ignoreDeps": [
     "python"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "/^rapidsai//"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "minimumReleaseAge": "7 days"
+    }
   ]
 }


### PR DESCRIPTION
Adds renovate config to wait for 1 week before bumping dependencies to help mitigate supply chain attacks.

xref rapidsai/build-planning#273
