### PR TITLE
chore(ci): enforce 'yamllint' checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,12 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.4
     hooks:
-        - id: check-metaschema
-          files: ^src/rapids_dependency_file_generator/schema.json$
-        - id: check-jsonschema
-          files: ^tests/examples/([^/]*)/dependencies.yaml$
-          args: ["--schemafile", "src/rapids_dependency_file_generator/schema.json"]
-        - id: check-github-workflows
+      - id: check-metaschema
+        files: ^src/rapids_dependency_file_generator/schema.json$
+      - id: check-jsonschema
+        files: ^tests/examples/([^/]*)/dependencies.yaml$
+        args: ["--schemafile", "src/rapids_dependency_file_generator/schema.json"]
+      - id: check-github-workflows
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.22
     hooks:
@@ -64,9 +64,18 @@ repos:
         exclude:
           (?x)
             ^tests/.*$
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            .*/output/expected/.*$
+          )
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.27.0
     hooks:
       - id: zizmor
 default_language_version:
-    python: python3
+  python: python3

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
--   id: rapids-dependency-file-generator
-    name: RAPIDS dependency file generator
-    description: Update dependency files according to the RAPIDS dependencies spec
-    entry: rapids-dependency-file-generator
-    language: python
-    files: "dependencies.yaml"
-    pass_filenames: false
-    args: [--warn-all, --strict]
+- id: rapids-dependency-file-generator
+  name: RAPIDS dependency file generator
+  description: Update dependency files according to the RAPIDS dependencies spec
+  entry: rapids-dependency-file-generator
+  language: python
+  files: "dependencies.yaml"
+  pass_filenames: false
+  args: [--warn-all, --strict]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/tests/examples/overlapping-deps/dependencies.yaml
+++ b/tests/examples/overlapping-deps/dependencies.yaml
@@ -44,7 +44,7 @@ dependencies:
         packages:
           - pip
           - pip:
-            - numpy>=2.0
+              - numpy>=2.0
   depends_on_pandas:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -67,9 +67,9 @@ dependencies:
           # intentional overlap (numpy) with depends_on_numpy's pip list, to
           # test that pip dependencies don't have duplicates
           - pip:
-            # intentionally not in alphabetical order
-            - numpy>=2.0
-            - folium
+              # intentionally not in alphabetical order
+              - numpy>=2.0
+              - folium
   rapids_build_skbuild:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/tests/examples/requirements-pip-dict/dependencies.yaml
+++ b/tests/examples/requirements-pip-dict/dependencies.yaml
@@ -11,4 +11,4 @@ dependencies:
         packages:
           - fsspec>=0.6.0
           - pip:
-            - pandas<1.0
+              - pandas<1.0


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.